### PR TITLE
Add support for parsing Xcode3ProjectDocumentLocation

### DIFF
--- a/lib/xcactivitylog/objects.rb
+++ b/lib/xcactivitylog/objects.rb
@@ -283,4 +283,8 @@ module XCActivityLog
     attribute :location_encoding, :int, 7
     attributes.freeze
   end
+
+  class Xcode3ProjectDocumentLocation < DVTDocumentLocation
+    attributes.freeze
+  end
 end


### PR DESCRIPTION
Adds the `Xcode3ProjectDocumentationLocation` class for deserialization